### PR TITLE
chore: actions/upload-artifact を v7、download-artifact を v8 に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: pnpm build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .astro/
 .DS_Store
 .claude/
+.pnpm-store/
 # Vim
 *.sw[a-z]
 *~


### PR DESCRIPTION
## Summary
- Node 20 ランタイム deprecation 警告 (2026-06-02 強制 / 2026-09-16 削除) への対応
- `actions/upload-artifact@v4` → `@v7` (Node 24)
- `actions/download-artifact@v4` → `@v8` (Node 24)
- `.pnpm-store/` を `.gitignore` に追加 (oxfmt のスキャン除外)

## 背景
`v2.1.4` のデプロイ時に GH Actions の annotations で v4 系の Node 20 deprecation 警告が出ていたため。両アクションとも v6 系で Node 24 に移行済みで、利用している入力 (`name` / `path` / `retention-days`) は v4 から変わっていない。

## ローカル検証
`act` で build job を回し、build pipeline (lint / format:check / check / build / `upload-artifact@v7` のロード) までは通過することを確認。実 artifact upload は `ACTIONS_RUNTIME_TOKEN` が必要なので act では検証不可、実 CI で要確認。

## Test plan
- [ ] PR の build job で `upload-artifact@v7` が成功する
- [ ] PR の lighthouse / a11y job で `download-artifact@v8` が成功する (continue-on-error: true なのでこれらは下流に影響しない)
- [ ] Node 20 deprecation 警告が消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)